### PR TITLE
Feat: Add learning pipeline core

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -23,6 +23,7 @@ mentor-bot-evolution/
 │   ├── context/              # Contextes React (AuthContext)
 │   ├── models/               # Modèles de base de données SQLAlchemy (user.py)
 │   ├── routes/               # Blueprints Flask (user, analysis, spaced_repetition, mastery, learning)
+│   ├── services/             # Services métiers (learning_pipeline, concept_extraction, flashcard_generation)
 │   ├── utils/                # Utilitaires backend (OCR, NLP) et frontend (API client)
 │   ├── App.jsx               # Composant React racine
 │   ├── index.css             # Styles Tailwind globaux
@@ -86,3 +87,19 @@ Les modèles SQLAlchemy sont définis dans `src/models/user.py` :
 - **Concept** : Une notion spécifique au sein d'une matière avec un score de maîtrise (0-100) et un statut (`completed`, `in-progress`, `not-started`).
 - **Card** : Carte mémoire pour l'algorithme de répétition espacée (conserve `interval`, `easiness_factor` et `next_review`).
 - **StudySession** : Enregistrement de session de travail (durée, précision) utilisé pour générer les graphiques d'analytics de progression.
+
+---
+
+## ⛓️ Pipeline d'Apprentissage (Learning Pipeline Core)
+
+Le pipeline d'apprentissage structure le flux d'analyse de documents et de génération de contenu pédagogique en 6 étapes :
+
+1. **Document** : L'utilisateur importe un document (PDF/Image/Texte) via l'interface.
+2. **Extraction** : Le module `src/utils/document_extraction.py` extrait le texte brut de manière résiliente.
+3. **Concepts** : Le service `src/services/concept_extraction.py` analyse la fréquence et la structure pour identifier les notions clés avec un score de confiance.
+4. **Flashcards** : Le service `src/services/flashcard_generation.py` crée des questions/réponses adaptées pour chaque concept.
+5. **Révision espacée** : Le pipeline planifie un calendrier de révisions (`revision_plan`) basé sur des intervalles exponentiels.
+6. **Progression** : Les révisions successives alimentent les statistiques de maîtrise persistées en base de données.
+
+Le pipeline est coordonné par le service central `src/services/learning_pipeline.py` et exposé via le champ `pipeline` dans la route d'analyse `/api/analysis/analyze-document`.
+

--- a/docs/DECISIONS/0008-learning-pipeline-core.md
+++ b/docs/DECISIONS/0008-learning-pipeline-core.md
@@ -1,0 +1,26 @@
+# ADR 0008 — Learning Pipeline Core
+
+## Status
+
+Accepted
+
+## Context
+
+MentorBot Evolution needs a clear learning pipeline connecting document analysis, concept extraction, flashcard generation, spaced repetition and progress tracking.
+
+## Decision
+
+Introduce a backend learning pipeline service with explicit heuristic/simulated markers where no external AI is used.
+
+## Constraints
+
+- Keep Flask.
+- Do not add external AI APIs.
+- Do not change Vercel.
+- Do not change database migrations.
+- Preserve existing API compatibility.
+- Mark simulated or heuristic outputs clearly.
+
+## Consequences
+
+The backend becomes easier to test, extend and connect to future AI features.

--- a/src/routes/analysis.py
+++ b/src/routes/analysis.py
@@ -14,6 +14,7 @@ from flask_jwt_extended import jwt_required, get_jwt_identity
 from src.utils.document_extraction import extract_text_from_document
 from src.utils.nlp import extract_concepts, analyze_sentiment
 from src.models.user import db, Subject, Concept, Card, StudySession
+from src.services.learning_pipeline import build_learning_pipeline
 
 
 analysis_bp = Blueprint("analysis", __name__)
@@ -294,6 +295,17 @@ def analyze_document():
             for ex in exercises
         )
 
+        try:
+            user_id = int(get_jwt_identity())
+        except (ValueError, TypeError, Exception):
+            user_id = 0
+
+        pipeline_data = build_learning_pipeline(
+            user_id=user_id,
+            subject_id=0,
+            document_text=analysis_result["extracted_text"]
+        )
+
         response = {
             "status": "success",
             "file_info": file_info,
@@ -330,6 +342,7 @@ def analyze_document():
                     1, total_study_time // (7 * 60)
                 ),  # Basé sur 1h/jour
             },
+            "pipeline": pipeline_data,
             "timestamp": datetime.now().isoformat(),
         }
 

--- a/src/services/concept_extraction.py
+++ b/src/services/concept_extraction.py
@@ -1,0 +1,38 @@
+"""
+Service d'extraction de concepts
+================================
+"""
+
+from src.utils.nlp import extract_concepts
+
+
+def extract_concepts_from_text(text: str, max_concepts: int = 10) -> list:
+    """
+    Extrait les concepts clés à partir d'un texte.
+    
+    Args:
+        text (str): Texte brut
+        max_concepts (int): Nombre maximum de concepts à extraire
+        
+    Returns:
+        list: Liste de dictionnaires contenant les concepts formatés
+    """
+    if not text:
+        return []
+
+    raw_concepts = extract_concepts(text, max_concepts=max_concepts)
+    formatted_concepts = []
+
+    for c in raw_concepts:
+        # Calcul heuristique de la confiance en fonction de la pertinence (fréquence)
+        relevance = c.get("relevance", 1)
+        confidence = min(0.95, 0.5 + (relevance * 0.05))
+
+        formatted_concepts.append({
+            "title": c["name"],
+            "description": f"Concept '{c['name']}' identifié à partir de l'analyse fréquentielle du texte.",
+            "confidence": round(confidence, 2),
+            "source": "heuristic"
+        })
+
+    return formatted_concepts

--- a/src/services/flashcard_generation.py
+++ b/src/services/flashcard_generation.py
@@ -1,0 +1,29 @@
+"""
+Service de génération de flashcards
+===================================
+"""
+
+
+def generate_flashcards_from_concepts(concepts: list) -> list:
+    """
+    Génère des flashcards heuristiques à partir de concepts extraits.
+    
+    Args:
+        concepts (list): Liste de concepts au format d'extraction
+        
+    Returns:
+        list: Liste de flashcards générées
+    """
+    flashcards = []
+
+    for c in concepts:
+        title = c["title"]
+        flashcards.append({
+            "concept_name": title,
+            "question": f"Qu'est-ce que le concept : '{title}' ?",
+            "answer": f"Le concept '{title}' est une notion importante identifiée dans le document. (Description heuristique : {c.get('description', '')})",
+            "difficulty": "medium",
+            "source": "heuristic"
+        })
+
+    return flashcards

--- a/src/services/learning_pipeline.py
+++ b/src/services/learning_pipeline.py
@@ -1,0 +1,74 @@
+"""
+Service central du pipeline d'apprentissage
+===========================================
+"""
+
+from datetime import datetime, timedelta
+from src.services.concept_extraction import extract_concepts_from_text
+from src.services.flashcard_generation import generate_flashcards_from_concepts
+
+
+def build_learning_pipeline(user_id: int, subject_id: int, document_text: str) -> dict:
+    """
+    Construit le pipeline d'apprentissage complet à partir d'un texte de document.
+    
+    Args:
+        user_id (int): ID de l'utilisateur
+        subject_id (int): ID de la matière / sujet
+        document_text (str): Texte extrait du document
+        
+    Returns:
+        dict: Bloc de données du pipeline d'apprentissage
+    """
+    if not document_text:
+        return {
+            "document_summary": "Aucun contenu à résumer.",
+            "concepts": [],
+            "flashcards": [],
+            "revision_plan": [],
+            "is_simulated": True,
+            "pipeline_version": "0.1"
+        }
+
+    # 1. Extraction de concepts (Heuristique)
+    concepts = extract_concepts_from_text(document_text)
+
+    # 2. Génération de flashcards (Heuristique)
+    flashcards = generate_flashcards_from_concepts(concepts)
+
+    # 3. Planning de révision (Courbe d'oubli espacée)
+    revision_plan = []
+    now = datetime.utcnow()
+    intervals = [1, 3, 7, 14, 30]  # Jours d'intervalle typiques
+
+    for c in concepts:
+        concept_schedule = []
+        for i, interval in enumerate(intervals):
+            scheduled_date = now + timedelta(days=interval)
+            concept_schedule.append({
+                "review_step": i + 1,
+                "interval_days": interval,
+                "scheduled_date": scheduled_date.isoformat() + "Z",
+                "target_confidence": round(0.7 + (i * 0.05), 2)
+            })
+        
+        revision_plan.append({
+            "concept_name": c["title"],
+            "schedule": concept_schedule
+        })
+
+    # 4. Résumé simplifié du document (Heuristique)
+    word_count = len(document_text.split())
+    summary = (
+        f"Document contenant {word_count} mots. "
+        f"L'analyse a identifié {len(concepts)} concepts clés à étudier en priorité."
+    )
+
+    return {
+        "document_summary": summary,
+        "concepts": concepts,
+        "flashcards": flashcards,
+        "revision_plan": revision_plan,
+        "is_simulated": True,  # Clé obligatoire pour signifier le mode local/heuristique sans IA externe
+        "pipeline_version": "0.1"
+    }

--- a/tests/test_learning_pipeline.py
+++ b/tests/test_learning_pipeline.py
@@ -1,0 +1,99 @@
+import os
+import sys
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from main import app
+from src.services.learning_pipeline import build_learning_pipeline
+from src.services.concept_extraction import extract_concepts_from_text
+from src.services.flashcard_generation import generate_flashcards_from_concepts
+from tests.test_backend_flask import client, auth_headers
+
+
+def test_concept_extraction_service():
+    """Vérifie que le service d'extraction extrait des concepts d'un texte simple."""
+    text = "The TOEIC exam evaluates listening and reading skills. Grammar is important."
+    concepts = extract_concepts_from_text(text, max_concepts=3)
+    
+    assert isinstance(concepts, list)
+    assert len(concepts) > 0
+    for concept in concepts:
+        assert "title" in concept
+        assert "description" in concept
+        assert "confidence" in concept
+        assert concept["source"] == "heuristic"
+
+
+def test_flashcard_generation_service():
+    """Vérifie que les flashcards sont bien générées à partir des concepts."""
+    concepts = [
+        {"title": "Listening Skills", "description": "Practice listening", "confidence": 0.8, "source": "heuristic"},
+        {"title": "Reading Comprehension", "description": "Practice reading", "confidence": 0.95, "source": "heuristic"}
+    ]
+    flashcards = generate_flashcards_from_concepts(concepts)
+    
+    assert isinstance(flashcards, list)
+    assert len(flashcards) == 2
+    for card in flashcards:
+        assert "concept_name" in card
+        assert "question" in card
+        assert "answer" in card
+        assert card["difficulty"] == "medium"
+        assert card["source"] == "heuristic"
+
+
+def test_learning_pipeline_service():
+    """Vérifie que le pipeline d'apprentissage produit le dictionnaire complet attendu."""
+    text = "This is a simple document about TOEIC and spaced repetition techniques."
+    pipeline = build_learning_pipeline(user_id=1, subject_id=1, document_text=text)
+    
+    assert isinstance(pipeline, dict)
+    assert "document_summary" in pipeline
+    assert "concepts" in pipeline
+    assert "flashcards" in pipeline
+    assert "revision_plan" in pipeline
+    assert pipeline["is_simulated"] is True
+    assert pipeline["pipeline_version"] == "0.1"
+    
+    # Vérifie que la planification de révision est générée
+    assert len(pipeline["revision_plan"]) > 0
+    for plan in pipeline["revision_plan"]:
+        assert "concept_name" in plan
+        assert "schedule" in plan
+        assert len(plan["schedule"]) == 5  # 5 étapes de révision par défaut
+
+
+def test_analyze_document_route_returns_pipeline(client, auth_headers):
+    """Vérifie que la route /api/analysis/analyze-document intègre bien le bloc pipeline dans sa réponse."""
+    import io
+    data = {
+        "file": (
+            io.BytesIO(
+                b"Grammar rules and business communication vocabulary are critical for TOEIC preparation."
+            ),
+            "lesson.txt",
+        )
+    }
+    response = client.post(
+        "/api/analysis/analyze-document",
+        headers=auth_headers,
+        data=data,
+        content_type="multipart/form-data",
+    )
+    assert response.status_code == 200
+    res_data = response.get_json()
+    
+    # Compatibilité ancienne route préservée
+    assert "status" in res_data
+    assert "analysis" in res_data
+    assert "generated_content" in res_data
+    
+    # Nouveau bloc pipeline présent
+    assert "pipeline" in res_data
+    pipeline = res_data["pipeline"]
+    assert "document_summary" in pipeline
+    assert "concepts" in pipeline
+    assert "flashcards" in pipeline
+    assert "revision_plan" in pipeline
+    assert pipeline["is_simulated"] is True


### PR DESCRIPTION
## Summary

This PR introduces the first backend core for the MentorBot learning pipeline:

Document → Extraction → Concepts → Flashcards → Revision Plan → Progression-ready output

## Changes

- Adds `src/services/learning_pipeline.py`
- Adds `src/services/concept_extraction.py`
- Adds `src/services/flashcard_generation.py`
- Updates `/api/analysis/analyze-document` to include a new `pipeline` response block
- Adds tests for concept extraction, flashcard generation, full pipeline output, and API integration
- Documents the decision in `docs/DECISIONS/0008-learning-pipeline-core.md`
- Updates `docs/ARCHITECTURE.md`

## Scope

This PR does not add external AI APIs, does not change Vercel, does not modify dependencies, and does not alter database migrations.

## Validation

Passed:

- `python -m pytest -q` → 15 passed
- `python -m compileall main.py src api backend tests`
- `npm run lint`
- `npm run build`
- Vercel check → success

## Notes

The pipeline currently uses local heuristic logic and explicitly marks generated output with `is_simulated: true`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a learning pipeline to document analysis results, including extracted concepts, flashcard suggestions, and a spaced revision plan.
  * Document analysis responses now include a new pipeline section with richer study guidance.

* **Documentation**
  * Expanded architecture and decision notes to cover the new backend learning workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->