### PR TITLE
feat: module d’apprentissage adaptatif TOEIC et informatique

### DIFF
--- a/docs/MODULE_APPRENTISSAGE_ADAPTATIF_2026-08-11.md
+++ b/docs/MODULE_APPRENTISSAGE_ADAPTATIF_2026-08-11.md
@@ -1,0 +1,52 @@
+# Module d’apprentissage adaptatif — TOEIC et informatique
+
+**Auteur : Manus AI**  
+**Date : 11 août 2026**
+
+## Finalité
+
+Le module étend le planificateur FSRS déjà intégré à Mentor Evolution. Il ne remplace pas la compréhension, les projets ou les exercices pratiques par des cartes. Il permet de **réactiver au bon moment les éléments à mémoriser** : vocabulaire et collocations TOEIC, règles grammaticales, commandes, protocoles, définitions, concepts et heuristiques informatiques.
+
+> La planification est adaptative au niveau de chaque carte : elle exploite l’historique de rappels de cette carte. Elle ne déduit pas un profil cognitif caché, ne déclare pas de compétence professionnelle et n’optimise pas de poids individuels sans historique suffisant.
+
+FSRS associe explicitement la rétention souhaitée à un compromis entre connaissances récupérables et charge de travail. Ses graphiques et simulations dépendent des paramètres et de l’historique de chaque apprenant ; ils ne doivent donc pas être présentés comme une prédiction universelle. [1]
+
+## Décisions de conception
+
+| Élément | Décision | Justification |
+|---|---|---|
+| Unité de planification | Chaque `Card` dispose d’un état FSRS et d’un journal `ReviewLog` existants. | Les erreurs, délais et rappels d’une notion ne doivent pas influencer arbitrairement une autre notion. |
+| Domaine | Chaque carte porte un domaine `language`, `computing`, `productivity`, `data`, `infrastructure`, `security` ou `general`. | Les sessions peuvent distinguer vocabulaire TOEIC et informatique tout en conservant le même moteur. |
+| Profil adaptatif | L’utilisateur peut choisir une rétention cible par domaine. En l’absence de profil, son réglage global est conservé. | La rétention cible règle un compromis explicite ; elle n’est pas ajustée silencieusement. [1] |
+| Valeurs autorisées | 80 % à 97 %, avec valeur de repli 90 %. | Ces bornes correspondent à celles déjà protégées par le planificateur du produit. |
+| Sessions ciblées | Une session peut ne montrer que les cartes d’un domaine effectivement dues. | Le TOEIC et l’informatique deviennent des espaces de pratique distincts, sans doubler les données. |
+| Explicabilité | Le tableau expose cartes dues, revues récentes, taux descriptif de rappel, délai estimé et rétention configurée. | Les recommandations reposent sur des données observées, pas sur une promesse de score ou de maîtrise. |
+
+## Parcours utilisateur
+
+| Étape | Vocabulaire TOEIC | Informatique |
+|---|---|---|
+| Créer | Carte liée au parcours Langues, étiquetée `language`. | Carte liée au parcours Fondamentaux de l’informatique, étiquetée `computing`. |
+| Réviser | Répondre avant de voir une définition, un exemple ou une collocation. | Expliquer un concept, une commande ou le rôle d’un protocole avant correction. |
+| Évaluer | Choisir À revoir, Difficile, Bien ou Facile. | Même échelle de rappel, sans prétendre évaluer l’exécution d’un projet. |
+| Adapter | FSRS calcule la prochaine échéance de la carte et le journal conserve le résultat. | Même mécanisme, avec une session filtrée par domaine et un objectif de rétention choisi. |
+| Compléter | Ajouter écoute, lecture et production hors cartes. | Ajouter laboratoire autorisé, diagnostic et artefact pratique hors cartes. |
+
+## Contrats proposés
+
+| Endpoint | Méthode | Rôle |
+|---|---|---|
+| `/api/spaced-repetition/adaptive-overview` | `GET` | Retourner les domaines effectivement étudiés, les cartes dues, les revues récentes et les indicateurs descriptifs. |
+| `/api/spaced-repetition/adaptive-profiles` | `GET` | Retourner la rétention globale, les profils par domaine et leurs limites. |
+| `/api/spaced-repetition/adaptive-profiles/<domain>` | `PUT` | Enregistrer un objectif de rétention explicite pour un domaine autorisé. |
+| `/api/spaced-repetition/get-due-cards?domain=<domain>` | `GET` | Démarrer une session ciblée avec uniquement les cartes dues du domaine. |
+
+La route de revue emploie le profil du domaine de la carte si un profil explicite existe. Le retour affiche toujours l’objectif effectif réellement appliqué et la date d’échéance calculée.
+
+## Critères d’acceptation
+
+Le module doit permettre de créer et réviser des cartes de vocabulaire TOEIC et de notions informatiques avec le même moteur FSRS, mais dans des sessions séparables par domaine. Un changement d’objectif de rétention doit être validé, persistant et utilisé lors de la revue suivante. Les cartes et journaux antérieurs doivent rester compatibles. Aucune session ne doit afficher de métrique fictive lorsque l’utilisateur ne possède aucune donnée dans le domaine.
+
+## Références
+
+[1] [FSRS4Anki — *The Optimal Retention*](https://github.com/open-spaced-repetition/fsrs4anki/wiki/The-optimal-retention)

--- a/migrations/versions/e4a9b2c7d6f1_add_adaptive_learning_profiles.py
+++ b/migrations/versions/e4a9b2c7d6f1_add_adaptive_learning_profiles.py
@@ -1,0 +1,36 @@
+"""Add per-domain adaptive learning profiles.
+
+Revision ID: e4a9b2c7d6f1
+Revises: d3f8a1b2c4d5
+Create Date: 2026-08-11
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "e4a9b2c7d6f1"
+down_revision = "d3f8a1b2c4d5"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column("card", sa.Column("learning_domain", sa.String(length=50), nullable=True))
+    op.create_table(
+        "adaptive_learning_profile",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("user_id", sa.Integer(), sa.ForeignKey("user.id"), nullable=False),
+        sa.Column("domain", sa.String(length=50), nullable=False),
+        sa.Column("desired_retention", sa.Float(), nullable=False, server_default="0.9"),
+        sa.Column("created_at", sa.DateTime(), nullable=True),
+        sa.Column("updated_at", sa.DateTime(), nullable=True),
+        sa.UniqueConstraint("user_id", "domain", name="uq_adaptive_profile_user_domain"),
+    )
+    op.create_index("ix_adaptive_learning_profile_user_id", "adaptive_learning_profile", ["user_id"])
+
+
+def downgrade():
+    op.drop_index("ix_adaptive_learning_profile_user_id", table_name="adaptive_learning_profile")
+    op.drop_table("adaptive_learning_profile")
+    op.drop_column("card", "learning_domain")

--- a/src/components/MasteryPlan/AdaptiveLearning.jsx
+++ b/src/components/MasteryPlan/AdaptiveLearning.jsx
@@ -1,0 +1,118 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import axios from 'axios';
+import { BarChart3, BrainCircuit, Clock3, Loader2, Play, Save, SlidersHorizontal } from 'lucide-react';
+import { useAuth } from '../../context/AuthContext.jsx';
+import { Badge } from '../ui/badge';
+import { Button } from '../ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '../ui/card';
+
+const displayNames = {
+  language: 'Anglais et TOEIC',
+  computing: 'Informatique',
+  productivity: 'Bureautique',
+  data: 'Données et visualisation',
+  infrastructure: 'Réseau et systèmes',
+  security: 'Cybersécurité',
+  general: 'Parcours libre',
+};
+
+const AdaptiveLearning = ({ onStartDomainSession }) => {
+  const { token } = useAuth();
+  const [domains, setDomains] = useState([]);
+  const [profiles, setProfiles] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [savingDomain, setSavingDomain] = useState(null);
+  const [error, setError] = useState(null);
+
+  const loadAdaptiveData = useCallback(async () => {
+    if (!token) {
+      setLoading(false);
+      return;
+    }
+    try {
+      setLoading(true);
+      setError(null);
+      const authConfig = { headers: { Authorization: `Bearer ${token}` } };
+      const [overviewResponse, profilesResponse] = await Promise.all([
+        axios.get('/api/spaced-repetition/adaptive-overview', authConfig),
+        axios.get('/api/spaced-repetition/adaptive-profiles', authConfig),
+      ]);
+      if (overviewResponse.data.status !== 'success' || profilesResponse.data.status !== 'success') {
+        throw new Error('Les données adaptatives ne sont pas disponibles.');
+      }
+      setDomains(overviewResponse.data.domains || []);
+      setProfiles(profilesResponse.data.profiles || []);
+    } catch (requestError) {
+      setError(requestError.message || 'Impossible de charger le module adaptatif.');
+    } finally {
+      setLoading(false);
+    }
+  }, [token]);
+
+  useEffect(() => { loadAdaptiveData(); }, [loadAdaptiveData]);
+
+  const profileByDomain = useMemo(
+    () => Object.fromEntries(profiles.map((profile) => [profile.domain, profile])),
+    [profiles],
+  );
+  const visibleDomains = domains.filter((domain) => domain.cards_total > 0 || ['language', 'computing'].includes(domain.domain));
+
+  const updateRetention = async (domain, value) => {
+    try {
+      setSavingDomain(domain);
+      setError(null);
+      const authConfig = { headers: { Authorization: `Bearer ${token}` } };
+      const response = await axios.put(
+        `/api/spaced-repetition/adaptive-profiles/${domain}`,
+        { desired_retention: Number(value) },
+        authConfig,
+      );
+      if (response.data.status !== 'success') throw new Error(response.data.message || 'Enregistrement impossible');
+      await loadAdaptiveData();
+    } catch (requestError) {
+      setError(requestError.message || 'Impossible d’enregistrer ce réglage.');
+    } finally {
+      setSavingDomain(null);
+    }
+  };
+
+  if (loading) return <div className="flex items-center gap-2 text-sm text-slate-600"><Loader2 className="h-4 w-4 animate-spin" />Calcul des priorités de révision…</div>;
+
+  return (
+    <div className="space-y-5">
+      <Card className="border-indigo-200 bg-gradient-to-br from-indigo-50 via-white to-teal-50 shadow-sm">
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2 text-lg"><BrainCircuit className="h-5 w-5 text-indigo-700" />Apprentissage adaptatif</CardTitle>
+          <CardDescription>Chaque carte est planifiée par FSRS à partir de vos rappels. La rétention cible est un choix explicite : l’augmenter peut accroître la charge de révision.</CardDescription>
+        </CardHeader>
+      </Card>
+
+      {error && <div className="rounded-xl border border-rose-200 bg-rose-50 p-3 text-sm text-rose-800">Erreur : {error}</div>}
+
+      <div className="grid gap-4 lg:grid-cols-2">
+        {visibleDomains.map((domain) => {
+          const profile = profileByDomain[domain.domain];
+          const retention = profile?.desired_retention ?? domain.desired_retention;
+          const isSaving = savingDomain === domain.domain;
+          return (
+            <Card key={domain.domain} className="border-slate-200 shadow-sm">
+              <CardHeader className="pb-3">
+                <div className="flex items-start justify-between gap-3"><div><CardTitle className="text-base">{displayNames[domain.domain] || domain.label}</CardTitle><CardDescription className="mt-1">{domain.cards_total} carte{domain.cards_total > 1 ? 's' : ''} suivie{domain.cards_total > 1 ? 's' : ''}</CardDescription></div><Badge variant="outline" className="border-indigo-200 bg-indigo-50 text-indigo-800">{domain.cards_due} due{domain.cards_due > 1 ? 's' : ''}</Badge></div>
+              </CardHeader>
+              <CardContent className="space-y-4">
+                <div className="grid grid-cols-2 gap-3 text-sm"><div className="rounded-lg bg-slate-50 p-3"><p className="flex items-center gap-1 text-xs text-slate-500"><Clock3 className="h-3.5 w-3.5" />Revues sur 30 jours</p><p className="mt-1 text-lg font-semibold text-slate-900">{domain.reviews_last_30_days}</p></div><div className="rounded-lg bg-slate-50 p-3"><p className="flex items-center gap-1 text-xs text-slate-500"><BarChart3 className="h-3.5 w-3.5" />Rappel observé</p><p className="mt-1 text-lg font-semibold text-slate-900">{domain.recall_rate === null ? '—' : `${Math.round(domain.recall_rate * 100)} %`}</p></div></div>
+                <div className="rounded-lg border border-slate-200 p-3"><p className="text-xs font-medium text-slate-700">Rétention cible</p><div className="mt-2 flex items-center gap-2"><select aria-label={`Rétention cible ${displayNames[domain.domain] || domain.label}`} value={retention} onChange={(event) => updateRetention(domain.domain, event.target.value)} disabled={isSaving} className="w-full rounded-md border border-slate-300 bg-white px-2 py-1.5 text-sm"><option value="0.80">80 % — charge réduite</option><option value="0.85">85 %</option><option value="0.90">90 % — équilibre</option><option value="0.93">93 %</option><option value="0.95">95 % — charge élevée</option><option value="0.97">97 % — charge très élevée</option></select><Save className="h-4 w-4 shrink-0 text-slate-500" /></div><p className="mt-2 text-xs text-slate-500">Appliquée à la prochaine revue de ce domaine. Source : {domain.retention_source === 'domain_profile' ? 'préférence du domaine' : 'préférence globale'}.</p></div>
+                <p className="text-sm leading-5 text-slate-600">{domain.recommendation.message}</p>
+                <Button type="button" className="w-full bg-indigo-700 hover:bg-indigo-800" disabled={domain.cards_due === 0} onClick={() => onStartDomainSession?.(domain.domain)}><Play className="mr-2 h-4 w-4" />Réviser {displayNames[domain.domain] || domain.label}</Button>
+              </CardContent>
+            </Card>
+          );
+        })}
+      </div>
+
+      <Card className="border-slate-200 shadow-sm"><CardContent className="flex gap-3 p-5"><SlidersHorizontal className="mt-0.5 h-5 w-5 shrink-0 text-indigo-700" /><p className="text-sm leading-6 text-slate-600">Le module organise le rappel de vocabulaire, définitions, commandes et concepts. Pour maîtriser l’anglais ou l’informatique, complétez ces cartes par de l’écoute, des projets, des exercices pratiques et des explications justifiées.</p></CardContent></Card>
+    </div>
+  );
+};
+
+export default AdaptiveLearning;

--- a/src/components/MasteryPlan/MasteryDashboard.jsx
+++ b/src/components/MasteryPlan/MasteryDashboard.jsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import axios from 'axios';
-import { BarChart3, BookOpen, CheckCircle, Clock3, FileUp, ListChecks, Sparkles, Target } from 'lucide-react';
+import { BarChart3, BookOpen, BrainCircuit, CheckCircle, Clock3, FileUp, ListChecks, Sparkles, Target } from 'lucide-react';
 import { Button } from '../ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '../ui/card';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '../ui/tabs';
@@ -9,6 +9,7 @@ import PlanGenerator from './PlanGenerator';
 import ValidationChecklist from './ValidationChecklist';
 import SpacedReview from './SpacedReview';
 import SpacedAnalytics from './SpacedAnalytics';
+import AdaptiveLearning from './AdaptiveLearning';
 import { useAuth } from '../../context/AuthContext.jsx';
 
 const MasteryDashboard = () => {
@@ -19,6 +20,7 @@ const MasteryDashboard = () => {
   const [loading, setLoading] = useState(true);
   const [analyzedDocs, setAnalyzedDocs] = useState([]);
   const [selectedConceptId, setSelectedConceptId] = useState('');
+  const [reviewDomain, setReviewDomain] = useState(null);
   const [error, setError] = useState(null);
 
   const concepts = useMemo(
@@ -69,12 +71,17 @@ const MasteryDashboard = () => {
     setActiveTab('validation');
   };
 
+  const startDomainReview = (domain) => {
+    setReviewDomain(domain);
+    setActiveTab('spaced');
+  };
+
   const renderOverview = () => (
     <div className="space-y-5">
       {error && <div className="rounded-xl border border-rose-200 bg-rose-50 p-3 text-sm text-rose-800">Erreur : {error}</div>}
       <div className="grid gap-4 sm:grid-cols-2">
         <Card className="border-slate-200 shadow-sm"><CardContent className="p-5"><div className="flex items-start justify-between"><div><p className="text-xs font-medium uppercase tracking-wide text-slate-500">Parcours actifs</p><p className="mt-2 text-3xl font-bold text-slate-950">{loading ? '—' : subjects.length}</p></div><BookOpen className="h-5 w-5 text-indigo-700" /></div><p className="mt-3 text-xs text-slate-600">Créez un parcours pour l’anglais, l’informatique ou toute autre compétence.</p></CardContent></Card>
-        <Card className="border-slate-200 shadow-sm"><CardContent className="p-5"><div className="flex items-start justify-between"><div><p className="text-xs font-medium uppercase tracking-wide text-slate-500">À revoir maintenant</p><p className="mt-2 text-3xl font-bold text-slate-950">{loading ? '—' : dueCount}</p></div><Clock3 className="h-5 w-5 text-emerald-700" /></div><p className="mt-3 text-xs text-slate-600">Ce total reflète les échéances enregistrées dans votre calendrier.</p><Button size="sm" className="mt-3 bg-emerald-700 hover:bg-emerald-800" onClick={() => setActiveTab('spaced')}>Démarrer la session</Button></CardContent></Card>
+        <Card className="border-slate-200 shadow-sm"><CardContent className="p-5"><div className="flex items-start justify-between"><div><p className="text-xs font-medium uppercase tracking-wide text-slate-500">À revoir maintenant</p><p className="mt-2 text-3xl font-bold text-slate-950">{loading ? '—' : dueCount}</p></div><Clock3 className="h-5 w-5 text-emerald-700" /></div><p className="mt-3 text-xs text-slate-600">Ce total reflète les échéances enregistrées dans votre calendrier.</p><Button size="sm" className="mt-3 bg-emerald-700 hover:bg-emerald-800" onClick={() => { setReviewDomain(null); setActiveTab('spaced'); }}>Démarrer la session</Button></CardContent></Card>
       </div>
 
       <Card className="border-slate-200 shadow-sm">
@@ -92,12 +99,13 @@ const MasteryDashboard = () => {
 
   return (
     <Tabs value={activeTab} onValueChange={setActiveTab} className="w-full">
-      <TabsList className="grid h-auto w-full grid-cols-3 gap-1 rounded-xl bg-slate-100 p-1 md:grid-cols-6">
+      <TabsList className="grid h-auto w-full grid-cols-3 gap-1 rounded-xl bg-slate-100 p-1 md:grid-cols-7">
         <TabsTrigger value="overview" className="text-xs sm:text-sm"><BookOpen className="mr-1.5 h-4 w-4" />Aujourd’hui</TabsTrigger>
         <TabsTrigger value="upload" className="text-xs sm:text-sm"><FileUp className="mr-1.5 h-4 w-4" />Importer</TabsTrigger>
         <TabsTrigger value="generator" className="text-xs sm:text-sm"><Target className="mr-1.5 h-4 w-4" />Parcours</TabsTrigger>
         <TabsTrigger value="validation" className="text-xs sm:text-sm"><CheckCircle className="mr-1.5 h-4 w-4" />Expliquer</TabsTrigger>
         <TabsTrigger value="spaced" className="text-xs sm:text-sm"><Sparkles className="mr-1.5 h-4 w-4" />Réviser</TabsTrigger>
+        <TabsTrigger value="adaptive" className="text-xs sm:text-sm"><BrainCircuit className="mr-1.5 h-4 w-4" />Adapter</TabsTrigger>
         <TabsTrigger value="analytics" className="text-xs sm:text-sm"><BarChart3 className="mr-1.5 h-4 w-4" />Données</TabsTrigger>
       </TabsList>
 
@@ -107,7 +115,8 @@ const MasteryDashboard = () => {
       <TabsContent value="validation" className="mt-6 space-y-4">
         {concepts.length ? <><Card className="border-slate-200 shadow-sm"><CardContent className="p-4"><label htmlFor="concept-select" className="mb-2 block text-sm font-semibold text-slate-800">Notion à expliquer</label><select id="concept-select" value={selectedConceptId} onChange={(event) => setSelectedConceptId(event.target.value)} className="w-full rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 focus:outline-none focus:ring-2 focus:ring-indigo-600">{concepts.map((concept) => <option key={concept.id} value={concept.id}>{concept.subjectName} — {concept.name}</option>)}</select></CardContent></Card>{selectedConcept && <ValidationChecklist concept={selectedConcept} onValidationComplete={refreshDashboard} />}</> : <Card><CardContent className="p-6 text-sm text-slate-600">Créez d’abord une matière et une notion pour démarrer une auto-explication.</CardContent></Card>}
       </TabsContent>
-      <TabsContent value="spaced" className="mt-6"><SpacedReview /></TabsContent>
+      <TabsContent value="spaced" className="mt-6"><SpacedReview key={reviewDomain || 'all'} domain={reviewDomain} /></TabsContent>
+      <TabsContent value="adaptive" className="mt-6"><AdaptiveLearning onStartDomainSession={startDomainReview} /></TabsContent>
       <TabsContent value="analytics" className="mt-6"><SpacedAnalytics /></TabsContent>
     </Tabs>
   );

--- a/src/components/MasteryPlan/SpacedReview.jsx
+++ b/src/components/MasteryPlan/SpacedReview.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import axios from 'axios';
 import { Brain, ChevronRight, Clock3, Lightbulb, Loader2, RotateCcw } from 'lucide-react';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '../ui/card';
@@ -13,7 +13,7 @@ const ratings = [
   { id: 'easy', label: 'Facile', hint: 'Je l’ai retrouvée immédiatement', className: 'bg-emerald-700 hover:bg-emerald-800' },
 ];
 
-const SpacedReview = () => {
+const SpacedReview = ({ domain = null }) => {
   const [loading, setLoading] = useState(true);
   const [cards, setCards] = useState([]);
   const [index, setIndex] = useState(0);
@@ -34,11 +34,12 @@ const SpacedReview = () => {
     setStartedAt(Date.now());
   };
 
-  const loadDue = async () => {
+  const loadDue = useCallback(async () => {
     try {
       setLoading(true);
       setError(null);
-      const response = await axios.get('/api/spaced-repetition/get-due-cards?limit=10');
+      const domainQuery = domain ? `&domain=${encodeURIComponent(domain)}` : '';
+      const response = await axios.get(`/api/spaced-repetition/get-due-cards?limit=10${domainQuery}`);
       const data = response.data;
       if (data.status !== 'success') throw new Error(data.message || 'Récupération échouée');
       setCards(data.due_cards || []);
@@ -52,9 +53,9 @@ const SpacedReview = () => {
     } finally {
       setLoading(false);
     }
-  };
+  }, [domain]);
 
-  useEffect(() => { loadDue(); }, []);
+  useEffect(() => { loadDue(); }, [loadDue]);
 
   const review = async (rating) => {
     if (!current || !revealed || feedback) return;
@@ -126,7 +127,7 @@ const SpacedReview = () => {
       <div className="flex flex-col justify-between gap-3 sm:flex-row sm:items-center">
         <div>
           <h3 className="flex items-center gap-2 text-lg font-semibold text-slate-900"><Brain className="h-5 w-5 text-indigo-700" />Session de rappel actif</h3>
-          <p className="mt-1 text-sm text-slate-600">Essayez de retrouver la réponse avant de consulter la correction.</p>
+          <p className="mt-1 text-sm text-slate-600">{domain ? `Session ciblée : ${domain === 'language' ? 'anglais et TOEIC' : domain === 'computing' ? 'informatique' : domain}. ` : ''}Essayez de retrouver la réponse avant de consulter la correction.</p>
         </div>
         <div className="flex items-center gap-2">
           <Badge variant="outline" className="border-indigo-200 bg-indigo-50 text-indigo-800">{remaining} carte{remaining > 1 ? 's' : ''} restante{remaining > 1 ? 's' : ''}</Badge>

--- a/src/models/user.py
+++ b/src/models/user.py
@@ -28,6 +28,7 @@ class User(db.Model):
     subjects = db.relationship("Subject", backref="owner", lazy=True)
     study_sessions = db.relationship("StudySession", backref="owner", lazy=True)
     review_logs = db.relationship("ReviewLog", backref="owner", lazy=True, cascade="all, delete-orphan")
+    adaptive_profiles = db.relationship("AdaptiveLearningProfile", backref="owner", lazy=True, cascade="all, delete-orphan")
 
     def set_password(self, password):
         self.password_hash = generate_password_hash(password)
@@ -37,6 +38,28 @@ class User(db.Model):
 
     def __repr__(self):
         return f"<User {self.username}>"
+
+
+class AdaptiveLearningProfile(db.Model):
+    """Explicit FSRS retention preference for one learner and one domain."""
+
+    id = db.Column(db.Integer, primary_key=True)
+    user_id = db.Column(db.Integer, db.ForeignKey("user.id"), nullable=False, index=True)
+    domain = db.Column(db.String(50), nullable=False)
+    desired_retention = db.Column(db.Float, nullable=False, default=0.90)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow)
+    updated_at = db.Column(db.DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
+
+    __table_args__ = (db.UniqueConstraint("user_id", "domain", name="uq_adaptive_profile_user_domain"),)
+
+    def to_dict(self):
+        return {
+            "id": self.id,
+            "domain": self.domain,
+            "desired_retention": self.desired_retention,
+            "created_at": self.created_at.isoformat() if self.created_at else None,
+            "updated_at": self.updated_at.isoformat() if self.updated_at else None,
+        }
 
 
 class Subject(db.Model):
@@ -120,6 +143,7 @@ class Card(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     user_id = db.Column(db.Integer, db.ForeignKey("user.id"), nullable=False)
     subject_id = db.Column(db.Integer, db.ForeignKey("subject.id"), nullable=True)
+    learning_domain = db.Column(db.String(50), nullable=True)
     concept_name = db.Column(db.String(200), nullable=False)
     front_content = db.Column(db.Text, default="")  # Question / front side
     back_content = db.Column(db.Text, default="")   # Answer / back side
@@ -174,6 +198,7 @@ class Card(db.Model):
         return {
             "id": self.id,
             "concept_name": self.concept_name,
+            "learning_domain": self.learning_domain or (self.subject.domain if self.subject else "general"),
             "front_content": self.front_content,
             "back_content": self.back_content,
             "difficulty": self.difficulty,

--- a/src/routes/spaced_repetition.py
+++ b/src/routes/spaced_repetition.py
@@ -10,7 +10,7 @@ from datetime import datetime, timedelta, timezone
 from flask import Blueprint, jsonify, request
 from flask_jwt_extended import get_jwt_identity, jwt_required
 
-from src.models.user import Card, ReviewLog, StudySession, User, db
+from src.models.user import AdaptiveLearningProfile, Card, ReviewLog, StudySession, Subject, User, db
 from src.services.fsrs_scheduler import (
     DEFAULT_RETENTION,
     MAX_RETENTION,
@@ -22,6 +22,13 @@ from src.services.fsrs_scheduler import (
     review_with_fsrs,
 )
 from src.services.pipeline_flashcard_import import import_pipeline_flashcards
+from src.services.adaptive_learning import (
+    ADAPTIVE_DOMAINS,
+    build_adaptive_overview,
+    get_effective_retention,
+    resolve_card_domain,
+)
+from src.services.domain_catalog import DOMAIN_OPTIONS
 
 spaced_repetition_bp = Blueprint("spaced_repetition", __name__)
 
@@ -58,9 +65,20 @@ def create_spaced_repetition_card():
             return jsonify({"status": "error", "message": "concept_name is required"}), 400
 
         tags = data.get("tags", [])
+        subject_id = data.get("subject_id")
+        subject = None
+        if subject_id is not None:
+            subject = Subject.query.filter_by(id=subject_id, user_id=user_id).first()
+            if not subject:
+                return jsonify({"status": "error", "message": "Subject not found"}), 404
+        requested_domain = str(data.get("learning_domain", data.get("domain", ""))).strip()
+        if requested_domain and requested_domain not in ADAPTIVE_DOMAINS:
+            return jsonify({"status": "error", "message": "Unknown learning domain"}), 400
+        learning_domain = requested_domain or (subject.domain if subject else "general")
         card = Card(
             user_id=user_id,
-            subject_id=data.get("subject_id"),
+            subject_id=subject_id,
+            learning_domain=learning_domain,
             concept_name=concept_name,
             front_content=str(data.get("content", data.get("front_content", ""))).strip(),
             back_content=str(data.get("back_content", "")).strip(),
@@ -99,9 +117,10 @@ def review_card():
             return jsonify({"status": "error", "message": "Card not found"}), 404
 
         user = db.session.get(User, user_id)
-        retention_target = normalize_desired_retention(
-            user.desired_retention if user else DEFAULT_RETENTION
-        )
+        if not user:
+            return jsonify({"status": "error", "message": "User not found"}), 404
+        learning_domain = resolve_card_domain(card)
+        retention_target, retention_source = get_effective_retention(user, learning_domain)
         result = review_with_fsrs(card.scheduler_state, rating, retention_target)
         response_time = _safe_response_time(data.get("response_time"))
 
@@ -145,6 +164,8 @@ def review_card():
             "next_review_in_minutes": result["scheduled_minutes"],
             "next_review_at": card.next_review.isoformat(),
             "retention_target": result["retention_target"],
+            "learning_domain": learning_domain,
+            "retention_source": retention_source,
             "memory_state": result["memory_state"],
             "retrievability_before": result["retrievability_before"],
             # Legacy alias preserved for clients that previously expected it.
@@ -164,13 +185,16 @@ def get_due_cards():
     try:
         user_id = int(get_jwt_identity())
         limit = _safe_limit(request.args.get("limit"), default=20)
-        due_cards = (
-            Card.query
-            .filter(Card.user_id == user_id, Card.next_review <= _utcnow_naive())
-            .order_by(Card.next_review.asc())
-            .limit(limit)
-            .all()
-        )
+        requested_domain = str(request.args.get("domain", "")).strip()
+        if requested_domain and requested_domain not in ADAPTIVE_DOMAINS:
+            return jsonify({"status": "error", "message": "Unknown learning domain"}), 400
+        due_cards = Card.query.filter(
+            Card.user_id == user_id,
+            Card.next_review <= _utcnow_naive(),
+        ).order_by(Card.next_review.asc()).all()
+        if requested_domain:
+            due_cards = [card for card in due_cards if resolve_card_domain(card) == requested_domain]
+        due_cards = due_cards[:limit]
         cards_data = [card.to_dict() for card in due_cards]
         average_seconds = (
             sum(card.average_response_time for card in due_cards if card.review_count > 0)
@@ -183,6 +207,7 @@ def get_due_cards():
             "due_cards": cards_data,
             "total_due": len(cards_data),
             "estimated_time_minutes": estimated_minutes,
+            "domain": requested_domain or None,
             "scheduling_method": "FSRS pour les cartes déjà migrées ; état initial pour les nouvelles cartes.",
         })
     except Exception:
@@ -228,6 +253,91 @@ def update_spaced_repetition_settings():
     except Exception:
         db.session.rollback()
         return jsonify({"status": "error", "message": "Impossible de mettre à jour la rétention cible."}), 500
+
+
+@spaced_repetition_bp.route("/adaptive-profiles", methods=["GET"])
+@jwt_required()
+def get_adaptive_profiles():
+    """Return global and per-domain retention preferences with their source."""
+    user = db.session.get(User, int(get_jwt_identity()))
+    if not user:
+        return jsonify({"status": "error", "message": "User not found"}), 404
+    explicit_profiles = {profile.domain: profile for profile in user.adaptive_profiles}
+    profiles = []
+    for domain in ADAPTIVE_DOMAINS:
+        retention, source = get_effective_retention(user, domain)
+        profile = explicit_profiles.get(domain)
+        profiles.append({
+            "domain": domain,
+            "label": DOMAIN_OPTIONS[domain],
+            "desired_retention": retention,
+            "retention_source": source,
+            "updated_at": profile.updated_at.isoformat() if profile and profile.updated_at else None,
+        })
+    return jsonify({
+        "status": "success",
+        "global_desired_retention": normalize_desired_retention(user.desired_retention),
+        "bounds": {"min": MIN_RETENTION, "max": MAX_RETENTION},
+        "profiles": profiles,
+        "explanation": "Une rétention plus élevée augmente généralement le nombre de révisions ; le réglage est appliqué uniquement aux futures revues du domaine.",
+    })
+
+
+@spaced_repetition_bp.route("/adaptive-profiles/<domain>", methods=["PUT"])
+@jwt_required()
+def update_adaptive_profile(domain):
+    """Persist a learner-approved FSRS retention target for one known domain."""
+    if domain not in ADAPTIVE_DOMAINS:
+        return jsonify({"status": "error", "message": "Unknown learning domain"}), 400
+    data = request.get_json(silent=True) or {}
+    try:
+        desired_retention = float(data.get("desired_retention"))
+    except (TypeError, ValueError):
+        return jsonify({"status": "error", "message": "desired_retention must be a number"}), 400
+    if not MIN_RETENTION <= desired_retention <= MAX_RETENTION:
+        return jsonify({
+            "status": "error",
+            "message": f"desired_retention must be between {MIN_RETENTION} and {MAX_RETENTION}",
+        }), 400
+
+    try:
+        user_id = int(get_jwt_identity())
+        profile = AdaptiveLearningProfile.query.filter_by(user_id=user_id, domain=domain).first()
+        if profile:
+            profile.desired_retention = desired_retention
+        else:
+            profile = AdaptiveLearningProfile(
+                user_id=user_id,
+                domain=domain,
+                desired_retention=desired_retention,
+            )
+            db.session.add(profile)
+        db.session.commit()
+        return jsonify({
+            "status": "success",
+            "profile": {
+                **profile.to_dict(),
+                "label": DOMAIN_OPTIONS[domain],
+                "retention_source": "domain_profile",
+            },
+        })
+    except Exception:
+        db.session.rollback()
+        return jsonify({"status": "error", "message": "Impossible de mettre à jour le profil adaptatif."}), 500
+
+
+@spaced_repetition_bp.route("/adaptive-overview", methods=["GET"])
+@jwt_required()
+def get_adaptive_overview():
+    """Expose per-domain workload and recall data without score prediction."""
+    user = db.session.get(User, int(get_jwt_identity()))
+    if not user:
+        return jsonify({"status": "error", "message": "User not found"}), 404
+    return jsonify({
+        "status": "success",
+        "domains": build_adaptive_overview(user, _utcnow_naive()),
+        "explanation": "Les indicateurs décrivent vos cartes et revues enregistrées. Ils ne constituent ni un diagnostic ni une prédiction de réussite.",
+    })
 
 
 @spaced_repetition_bp.route("/get-schedule", methods=["GET"])

--- a/src/services/adaptive_learning.py
+++ b/src/services/adaptive_learning.py
@@ -1,0 +1,105 @@
+"""Transparent per-domain helpers for the shared FSRS learning module."""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from datetime import datetime, timedelta
+
+from src.models.user import AdaptiveLearningProfile, Card, ReviewLog
+from src.services.domain_catalog import DOMAIN_OPTIONS
+from src.services.fsrs_scheduler import DEFAULT_RETENTION, normalize_desired_retention
+
+
+ADAPTIVE_DOMAINS = tuple(DOMAIN_OPTIONS.keys())
+
+
+def resolve_card_domain(card: Card) -> str:
+    """Return the persisted card domain, then its subject domain, then general."""
+    if card.learning_domain in ADAPTIVE_DOMAINS:
+        return card.learning_domain
+    if card.subject and card.subject.domain in ADAPTIVE_DOMAINS:
+        return card.subject.domain
+    return "general"
+
+
+def get_effective_retention(user, domain: str) -> tuple[float, str]:
+    """Return the explicit domain preference or the learner's global fallback."""
+    profile = AdaptiveLearningProfile.query.filter_by(user_id=user.id, domain=domain).first()
+    if profile:
+        return normalize_desired_retention(profile.desired_retention), "domain_profile"
+    return normalize_desired_retention(user.desired_retention or DEFAULT_RETENTION), "global_profile"
+
+
+def recommendation_for_domain(cards_total: int, cards_due: int, review_count: int, recall_rate: float | None) -> dict:
+    """Offer only data-based next actions; never predict achievement or ability."""
+    if cards_total == 0:
+        return {
+            "code": "add_cards",
+            "message": "Ajoutez des cartes si vous souhaitez pratiquer ce domaine par rappel espacé.",
+        }
+    if cards_due:
+        return {
+            "code": "review_due",
+            "message": "Des cartes sont dues : une courte session de rappel est prioritaire.",
+        }
+    if review_count >= 5 and recall_rate is not None and recall_rate < 0.70:
+        return {
+            "code": "reinforce",
+            "message": "Les rappels récents sont fragiles : réduisez l’ajout de nouvelles cartes et reformulez les notions difficiles.",
+        }
+    return {
+        "code": "continue",
+        "message": "Aucune carte n’est due actuellement ; poursuivez les exercices pratiques et revenez à l’échéance calculée.",
+    }
+
+
+def build_adaptive_overview(user, now: datetime) -> list[dict]:
+    """Build descriptive domain metrics from persisted cards and review logs."""
+    cards = Card.query.filter_by(user_id=user.id).all()
+    cards_by_domain: dict[str, list[Card]] = defaultdict(list)
+    card_domains: dict[int, str] = {}
+    for card in cards:
+        domain = resolve_card_domain(card)
+        cards_by_domain[domain].append(card)
+        card_domains[card.id] = domain
+
+    recent_logs = ReviewLog.query.filter(
+        ReviewLog.user_id == user.id,
+        ReviewLog.reviewed_at >= now - timedelta(days=30),
+    ).all()
+    logs_by_domain: dict[str, list[ReviewLog]] = defaultdict(list)
+    for log in recent_logs:
+        logs_by_domain[card_domains.get(log.card_id, "general")].append(log)
+
+    profile_domains = {profile.domain for profile in user.adaptive_profiles}
+    # Les deux parcours initiaux doivent être configurables même avant la
+    # première carte : le module sert aussi de point d’entrée pour TOEIC et informatique.
+    represented_domains = set(cards_by_domain) | profile_domains | {"language", "computing"}
+    overview = []
+    for domain in sorted(represented_domains):
+        domain_cards = cards_by_domain[domain]
+        domain_logs = logs_by_domain[domain]
+        reviewed_count = len(domain_logs)
+        successful_count = sum(log.rating != "again" for log in domain_logs)
+        recall_rate = round(successful_count / reviewed_count, 3) if reviewed_count else None
+        average_response_seconds = (
+            round(sum(log.response_time for log in domain_logs) / reviewed_count, 1)
+            if reviewed_count else None
+        )
+        due_count = sum(card.is_due for card in domain_cards)
+        retention, retention_source = get_effective_retention(user, domain)
+        overview.append({
+            "domain": domain,
+            "label": DOMAIN_OPTIONS[domain],
+            "cards_total": len(domain_cards),
+            "cards_due": due_count,
+            "reviews_last_30_days": reviewed_count,
+            "recall_rate": recall_rate,
+            "average_response_seconds": average_response_seconds,
+            "desired_retention": retention,
+            "retention_source": retention_source,
+            "recommendation": recommendation_for_domain(
+                len(domain_cards), due_count, reviewed_count, recall_rate,
+            ),
+        })
+    return overview

--- a/tests/test_backend_flask.py
+++ b/tests/test_backend_flask.py
@@ -285,3 +285,85 @@ def test_custom_learning_path_supports_goal_and_deadline(client, auth_headers):
     assert subject["objective_label"] == "Automatiser un rapport mensuel"
     assert subject["target_date"] == "2026-12-31"
     assert subject["concepts"][0]["competency_type"] == "procedure"
+
+
+def test_adaptive_profiles_filter_sessions_and_apply_domain_retention(client, auth_headers):
+    language_path_response = client.post(
+        "/api/mastery/create-path",
+        headers=auth_headers,
+        json={"template_id": "toeic-foundations"},
+    )
+    computing_path_response = client.post(
+        "/api/mastery/create-path",
+        headers=auth_headers,
+        json={"template_id": "computing-foundations"},
+    )
+    assert language_path_response.status_code == 201
+    assert computing_path_response.status_code == 201
+    language_subject_id = language_path_response.get_json()["subject"]["id"]
+    computing_subject_id = computing_path_response.get_json()["subject"]["id"]
+
+    profile_response = client.put(
+        "/api/spaced-repetition/adaptive-profiles/language",
+        headers=auth_headers,
+        json={"desired_retention": 0.93},
+    )
+    assert profile_response.status_code == 200
+    assert profile_response.get_json()["profile"]["desired_retention"] == 0.93
+
+    language_card_response = client.post(
+        "/api/spaced-repetition/create-card",
+        headers=auth_headers,
+        json={
+            "subject_id": language_subject_id,
+            "concept_name": "Board meeting",
+            "front_content": "Que signifie board meeting ?",
+            "back_content": "Réunion du conseil d’administration.",
+        },
+    )
+    computing_card_response = client.post(
+        "/api/spaced-repetition/create-card",
+        headers=auth_headers,
+        json={
+            "subject_id": computing_subject_id,
+            "concept_name": "DNS",
+            "front_content": "Quel service associe un nom de domaine à une adresse IP ?",
+            "back_content": "Le DNS.",
+        },
+    )
+    assert language_card_response.status_code == 200
+    assert computing_card_response.status_code == 200
+    language_card = language_card_response.get_json()["card"]
+
+    language_due_response = client.get(
+        "/api/spaced-repetition/get-due-cards?domain=language",
+        headers=auth_headers,
+    )
+    assert language_due_response.status_code == 200
+    language_due = language_due_response.get_json()
+    assert language_due["domain"] == "language"
+    assert language_due["total_due"] == 1
+    assert language_due["due_cards"][0]["learning_domain"] == "language"
+
+    review_response = client.post(
+        "/api/spaced-repetition/review-card",
+        headers=auth_headers,
+        json={"card_id": language_card["id"], "rating": "good", "response_time": 8},
+    )
+    assert review_response.status_code == 200
+    review = review_response.get_json()
+    assert review["learning_domain"] == "language"
+    assert review["retention_target"] == 0.93
+    assert review["retention_source"] == "domain_profile"
+
+    overview_response = client.get(
+        "/api/spaced-repetition/adaptive-overview",
+        headers=auth_headers,
+    )
+    assert overview_response.status_code == 200
+    language_overview = next(
+        item for item in overview_response.get_json()["domains"] if item["domain"] == "language"
+    )
+    assert language_overview["cards_total"] == 1
+    assert language_overview["desired_retention"] == 0.93
+    assert language_overview["retention_source"] == "domain_profile"


### PR DESCRIPTION
## Module d’apprentissage adaptatif

Cette demande de fusion ajoute un module partagé de répétition espacée fondé sur FSRS pour les parcours **Anglais / TOEIC** et **Informatique**, sans remplacer les activités pratiques nécessaires à la maîtrise.

| Élément | Livraison |
|---|---|
| Profils par domaine | Objectif de rétention explicite et persistant par domaine, entre 80 % et 97 %. |
| Sessions ciblées | Les cartes dues peuvent être filtrées par domaine pour séparer TOEIC et informatique. |
| Planification | La révision applique le profil de domaine lorsqu’il existe et retourne la source du réglage. |
| Indicateurs | Cartes dues, revues sur 30 jours, rappel observé et recommandations uniquement fondées sur les données enregistrées. |
| Interface | Nouvel onglet **Adapter**, réglage par domaine et entrée vers les sessions ciblées. |
| Schéma | Migration réversible `e4a9b2c7d6f1` pour les profils et le domaine optionnel des cartes. |

## Validation

| Contrôle | Résultat |
|---|---|
| Installation reproductible depuis lockfile | Réussie, sans vulnérabilité npm |
| Tests backend | 26 tests réussis |
| Compilation Python | Réussie |
| Lint React | Réussi, sans avertissement |
| Build Vite | Réussi |
| Audit npm de production | 0 vulnérabilité |
| Migration Alembic | Upgrade, rollback, puis nouvel upgrade réussis sur une base isolée |
| Parcours navigateur | Authentification, affichage du module, profil Informatique, session de rappel TOEIC et feedback FSRS vérifiés |

La documentation de conception précise que le module planifie le rappel de cartes ; il ne prétend pas diagnostiquer l’apprenant, prédire une réussite ou remplacer les exercices pratiques.
