### PR TITLE
feat: socle TOEIC de vocabulaire professionnel

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Le projet conserve une architecture React/Vite côté client et Flask/SQLAlchemy
 |---|---|
 | Authentification par inscription, connexion et JWT | Disponible |
 | Catalogue de parcours explicites | Disponible : TOEIC, informatique, Excel, Power BI, réseau, cybersécurité et parcours libre |
+| Parcours « Préparation TOEIC » | Disponible avec un socle original de 36 cartes de vocabulaire professionnel, immédiatement planifiées dans le domaine Langues |
 | Parcours « Fondamentaux de l’informatique » | Disponible avec cinq notions initiales : données, algorithmique, systèmes, réseau et hygiène numérique |
 | Sujets, notions et critères de preuve | Persistés et génériques par domaine |
 | Cartes et répétition espacée FSRS | Disponibles, avec journal de revue et rétention cible configurable |
@@ -35,7 +36,7 @@ Le projet ne personnalise pas les contenus à partir de « styles d’apprentiss
 | Activité | Rappel, auto-explication, exercice pratique, diagnostic ou production ; les activités pratiques seront enrichies progressivement |
 | Preuve | Résultat observable d’une activité ; les cartes FSRS seules ne sont pas une certification |
 
-La documentation détaillée se trouve dans [l’architecture multi-domaines](docs/ARCHITECTURE_MULTI_DOMAINES_2026-08-11.md), [l’audit de généralisation](docs/AUDIT_GENERALISATION_MULTI_DOMAINES_2026-08-11.md) et les [notes de recherche](docs/RECHERCHE_MULTI_DOMAINES_2026-08-11.md).
+La documentation détaillée se trouve dans [l’architecture multi-domaines](docs/ARCHITECTURE_MULTI_DOMAINES_2026-08-11.md), [l’audit de généralisation](docs/AUDIT_GENERALISATION_MULTI_DOMAINES_2026-08-11.md), les [notes de recherche](docs/RECHERCHE_MULTI_DOMAINES_2026-08-11.md) et le [socle TOEIC initial](docs/PARCOURS_TOEIC_FONDATIONS.md).
 
 ## Limites actuelles et prochaines étapes
 

--- a/docs/PARCOURS_TOEIC_FONDATIONS.md
+++ b/docs/PARCOURS_TOEIC_FONDATIONS.md
@@ -1,0 +1,37 @@
+# Parcours TOEIC — vocabulaire professionnel : socle initial
+
+## Objectif et périmètre
+
+Le modèle **Préparation TOEIC** crée maintenant un socle de **36 cartes originales** de vocabulaire professionnel. Ce socle est conçu pour entraîner le rappel actif dans des situations de travail courantes. Il ne reproduit ni questions, ni passages, ni audio d’examens TOEIC, et il ne prédit aucun score.
+
+Le choix des thèmes s’appuie sur l’orientation professionnelle des ressources de préparation TOEIC d’ETS et sur les usages de communication au travail décrits par le British Council. [1] [2]
+
+| Bloc | Cartes | Exemples de notions |
+|---|---:|---|
+| Réunions | 6 | agenda, minutes, attend, postpone, consensus |
+| Courriel et projets | 6 | deadline, schedule, submit, approve, follow up |
+| Ressources humaines | 6 | applicant, vacancy, recruit, orientation, benefits |
+| Relation client | 6 | quote, invoice, purchase order, negotiate, refund |
+| Logistique et déplacements | 6 | shipment, delivery, inventory, warehouse, itinerary |
+| Finances et rapports | 6 | budget, revenue, expense, forecast, quarterly |
+
+## Structure d’une carte
+
+Chaque carte comporte une invitation à produire le mot ou l’expression avant d’observer la réponse. La correction contient la traduction ou définition opérationnelle, une collocation fréquente et une phrase professionnelle originale.
+
+> Exemple de logique de rappel : « Quel document demande le paiement de biens ou services fournis ? » → **invoice**, avec la collocation *issue / pay an invoice* et une phrase de contexte.
+
+Les cartes sont créées avec le domaine `language`, une échéance immédiate de première récupération et des étiquettes telles que `toeic`, `starter` et le thème concerné. Elles rejoignent donc directement la planification FSRS et les vues adaptatives du domaine Anglais / TOEIC.
+
+## Utilisation recommandée
+
+Après création du modèle TOEIC, commencez par une courte session de rappel sans consulter les corrections. Évaluez ensuite honnêtement la récupération. Le jeu initial est une base : complétez-le progressivement avec votre vocabulaire d’entreprise, des courriels réels anonymisés, de l’écoute et de la lecture chronométrée. Les cartes isolées ne remplacent pas la compréhension de documents, l’écoute ou la pratique communicative. [2]
+
+## Évolution prévue
+
+La prochaine extension de contenu doit ajouter des cartes de collocations, de grammaire en contexte, puis des activités liées à l’écoute et à la lecture. Les nouveaux lots devront rester originaux, contextualisés et passer par les mêmes contrôles de domaine et de répétition espacée.
+
+## Références
+
+[1]: https://www.ets.org/toeic/test-takers/prepare.html "TOEIC Test Preparation Materials — ETS"
+[2]: https://learnenglish.britishcouncil.org/free-resources/business "Business English — British Council"

--- a/docs/research_toeic_foundations_2026-08-11.md
+++ b/docs/research_toeic_foundations_2026-08-11.md
@@ -1,0 +1,15 @@
+# Références de conception — parcours TOEIC initial
+
+Le jeu de cartes initial est conçu comme un support de rappel actif pour l’anglais professionnel. Il ne reproduit ni questions, ni passages, ni audio d’examens protégés.
+
+## Orientation retenue
+
+ETS présente sa préparation TOEIC Listening and Reading autour de scénarios et tâches de travail, avec des exercices interactifs allant du débutant à l’avancé. [1] Amideast décrit la famille TOEIC comme une mesure des compétences d’anglais réelles des étudiants et employés dans des contextes académiques et professionnels. [2] Le British Council souligne l’utilité du vocabulaire professionnel et des compétences de communication dans des environnements de bureau, notamment les entretiens, les courriels clairs et les sujets d’affaires. [3]
+
+Le premier jeu doit donc privilégier des unités lexicales utiles dans des échanges professionnels : réunions, courriel et planification, recrutement, déplacements, achats et clientèle. Chaque carte doit demander une récupération avant d’afficher une traduction, une définition concise, une collocation et une phrase originale. Les cartes ne doivent pas être présentées comme une garantie de score TOEIC.
+
+## Références
+
+[1]: https://www.ets.org/toeic/test-takers/prepare.html "TOEIC Test Preparation Materials — ETS"
+[2]: https://www.amideast.org/usa/take-a-test/individuals/toeic "TOEIC Tests — Amideast"
+[3]: https://learnenglish.britishcouncil.org/free-resources/business "Business English — British Council"

--- a/src/components/MasteryPlan/PlanGenerator.jsx
+++ b/src/components/MasteryPlan/PlanGenerator.jsx
@@ -94,8 +94,9 @@ const PlanGenerator = ({ onPlanGenerated }) => {
       const config = token ? { headers: { Authorization: `Bearer ${token}` } } : {};
       const response = await axios.post('/api/mastery/create-path', payload, config);
       if (response.data.status !== 'success') throw new Error(response.data.message || 'Création impossible');
-      setCreatedPath(response.data.subject);
-      onPlanGenerated?.(response.data.subject);
+      const createdSubject = { ...response.data.subject, starterPack: response.data.starter_pack || null };
+      setCreatedPath(createdSubject);
+      onPlanGenerated?.(createdSubject);
     } catch (requestError) {
       setError(requestError.message || 'Impossible de créer le parcours.');
     } finally {
@@ -152,7 +153,7 @@ const PlanGenerator = ({ onPlanGenerated }) => {
         </CardContent>
       </Card>
 
-      {createdPath && <Card className="border-emerald-200 bg-emerald-50 shadow-sm"><CardContent className="flex gap-3 p-5"><CheckCircle2 className="mt-0.5 h-5 w-5 shrink-0 text-emerald-700" /><div><p className="font-semibold text-emerald-950">Parcours créé : {createdPath.name}</p><p className="mt-1 text-sm text-emerald-900">Vous pouvez maintenant sélectionner une notion, importer vos propres ressources, puis créer les cartes ou activités pertinentes.</p></div></CardContent></Card>}
+      {createdPath && <Card className="border-emerald-200 bg-emerald-50 shadow-sm"><CardContent className="flex gap-3 p-5"><CheckCircle2 className="mt-0.5 h-5 w-5 shrink-0 text-emerald-700" /><div><p className="font-semibold text-emerald-950">Parcours créé : {createdPath.name}</p>{createdPath.starterPack ? <p className="mt-1 text-sm text-emerald-900">{createdPath.starterPack.cards_created} cartes de vocabulaire professionnel ont été ajoutées pour démarrer les révisions. Elles constituent un socle éditorial à compléter par vos propres contenus, l’écoute et la pratique.</p> : <p className="mt-1 text-sm text-emerald-900">Vous pouvez maintenant sélectionner une notion, importer vos propres ressources, puis créer les cartes ou activités pertinentes.</p>}</div></CardContent></Card>}
     </div>
   );
 };

--- a/src/content/__init__.py
+++ b/src/content/__init__.py
@@ -1,0 +1,1 @@
+"""Paquets éditoriaux intégrés à Mentor Evolution."""

--- a/src/content/toeic_foundations.py
+++ b/src/content/toeic_foundations.py
@@ -1,0 +1,292 @@
+"""Paquet éditorial initial pour le parcours TOEIC.
+
+Les cartes sont des formulations originales consacrées à la communication
+professionnelle. Elles ne reproduisent ni questions, ni passages, ni audio
+d'un examen TOEIC. Elles servent de point de départ au rappel actif et non de
+prédiction de score.
+"""
+
+from copy import deepcopy
+
+
+TOEIC_FOUNDATIONS_PACK_ID = "toeic-business-vocabulary-foundations-v1"
+
+TOEIC_FOUNDATIONS_PACK = {
+    "id": TOEIC_FOUNDATIONS_PACK_ID,
+    "title": "TOEIC — vocabulaire professionnel : socle initial",
+    "template_id": "toeic-foundations",
+    "learning_domain": "language",
+    "description": (
+        "36 cartes originales de vocabulaire et collocations pour les réunions, "
+        "les courriels et projets, les ressources humaines, la relation client, "
+        "la logistique et les rapports financiers."
+    ),
+    "source": "editorial_original",
+    "license_note": "Contenu original du projet Mentor Evolution ; aucune question d’examen n’est reproduite.",
+    "learning_design": {
+        "method": "rappel actif avec correction concise, collocation et exemple original",
+        "usage": "Répondre sans regarder, vérifier la correction, puis choisir une évaluation honnête.",
+        "scope": "Socle lexical professionnel ; à compléter par écoute, lecture et production écrite.",
+    },
+    "cards": [
+        {
+            "concept_name": "Vocabulaire professionnel",
+            "question": "Réunion — Complétez : ‘Please send the ___ before the meeting.’ (ordre des sujets à traiter)",
+            "answer": "agenda — ordre des sujets d’une réunion. Collocation : set / send the agenda. Exemple : ‘The manager sent the agenda on Monday.’",
+            "difficulty": "easy",
+            "tags": ["toeic", "starter", "meetings", "agenda"],
+        },
+        {
+            "concept_name": "Vocabulaire professionnel",
+            "question": "Réunion — Quel mot anglais désigne le compte rendu officiel d’une réunion ?",
+            "answer": "minutes — compte rendu de réunion. Collocation : take / approve the minutes. Exemple : ‘Nina took the minutes during the meeting.’",
+            "difficulty": "medium",
+            "tags": ["toeic", "starter", "meetings", "minutes"],
+        },
+        {
+            "concept_name": "Vocabulaire professionnel",
+            "question": "Réunion — Complétez : ‘All department heads will ___ the conference.’ (être présents)",
+            "answer": "attend — assister à un événement. Collocation : attend a meeting / conference. Exemple : ‘All department heads will attend the conference.’",
+            "difficulty": "easy",
+            "tags": ["toeic", "starter", "meetings", "attend"],
+        },
+        {
+            "concept_name": "Vocabulaire professionnel",
+            "question": "Réunion — Quel verbe signifie reporter une réunion à une date ultérieure ?",
+            "answer": "postpone — reporter. Collocation : postpone a meeting until Friday. Exemple : ‘We postponed the meeting until Friday.’",
+            "difficulty": "medium",
+            "tags": ["toeic", "starter", "meetings", "postpone"],
+        },
+        {
+            "concept_name": "Vocabulaire professionnel",
+            "question": "Réunion — Complétez : ‘Could you ___ your availability by noon?’ (confirmer)",
+            "answer": "confirm — confirmer. Collocation : confirm availability / an appointment. Exemple : ‘Could you confirm your availability by noon?’",
+            "difficulty": "easy",
+            "tags": ["toeic", "starter", "meetings", "confirm"],
+        },
+        {
+            "concept_name": "Vocabulaire professionnel",
+            "question": "Réunion — Quel nom désigne un accord général atteint par un groupe ?",
+            "answer": "consensus — accord général. Collocation : reach a consensus. Exemple : ‘The team reached a consensus after a short discussion.’",
+            "difficulty": "medium",
+            "tags": ["toeic", "starter", "meetings", "consensus"],
+        },
+        {
+            "concept_name": "Vocabulaire professionnel",
+            "question": "Courriel et projets — Quel nom anglais désigne une échéance à respecter ?",
+            "answer": "deadline — échéance. Collocation : meet / extend a deadline. Exemple : ‘The design team met the deadline.’",
+            "difficulty": "easy",
+            "tags": ["toeic", "starter", "email-projects", "deadline"],
+        },
+        {
+            "concept_name": "Vocabulaire professionnel",
+            "question": "Courriel et projets — Complétez : ‘The updated ___ is attached to this email.’ (planning)",
+            "answer": "schedule — planning, calendrier. Collocation : update a schedule. Exemple : ‘The updated schedule is attached to this email.’",
+            "difficulty": "easy",
+            "tags": ["toeic", "starter", "email-projects", "schedule"],
+        },
+        {
+            "concept_name": "Vocabulaire professionnel",
+            "question": "Courriel et projets — Quel verbe signifie remettre officiellement un document ou une proposition ?",
+            "answer": "submit — remettre, soumettre. Collocation : submit a report / proposal. Exemple : ‘Please submit the report by Thursday.’",
+            "difficulty": "medium",
+            "tags": ["toeic", "starter", "email-projects", "submit"],
+        },
+        {
+            "concept_name": "Vocabulaire professionnel",
+            "question": "Courriel et projets — Complétez : ‘The director must ___ the final budget.’ (donner son accord)",
+            "answer": "approve — approuver. Collocation : approve a budget / request. Exemple : ‘The director approved the final budget.’",
+            "difficulty": "easy",
+            "tags": ["toeic", "starter", "email-projects", "approve"],
+        },
+        {
+            "concept_name": "Vocabulaire professionnel",
+            "question": "Courriel et projets — Quelle expression signifie relancer quelqu’un après un premier échange ?",
+            "answer": "follow up — relancer, assurer le suivi. Collocation : follow up on a request. Exemple : ‘I will follow up on your request tomorrow.’",
+            "difficulty": "medium",
+            "tags": ["toeic", "starter", "email-projects", "follow-up"],
+        },
+        {
+            "concept_name": "Vocabulaire professionnel",
+            "question": "Courriel et projets — Quel nom désigne un document joint à un email ?",
+            "answer": "attachment — pièce jointe. Collocation : add / open an attachment. Exemple : ‘Please review the attachment before the call.’",
+            "difficulty": "easy",
+            "tags": ["toeic", "starter", "email-projects", "attachment"],
+        },
+        {
+            "concept_name": "Vocabulaire professionnel",
+            "question": "Ressources humaines — Quel nom anglais désigne une personne qui postule à un emploi ?",
+            "answer": "applicant — candidat à un emploi. Collocation : qualified applicant. Exemple : ‘Each applicant completed an online form.’",
+            "difficulty": "medium",
+            "tags": ["toeic", "starter", "human-resources", "applicant"],
+        },
+        {
+            "concept_name": "Vocabulaire professionnel",
+            "question": "Ressources humaines — Quel mot désigne un poste vacant à pourvoir ?",
+            "answer": "vacancy — poste vacant. Collocation : fill a vacancy. Exemple : ‘The company plans to fill the vacancy quickly.’",
+            "difficulty": "medium",
+            "tags": ["toeic", "starter", "human-resources", "vacancy"],
+        },
+        {
+            "concept_name": "Vocabulaire professionnel",
+            "question": "Ressources humaines — Complétez : ‘The company plans to ___ two engineers this year.’ (recruter)",
+            "answer": "recruit — recruter. Collocation : recruit staff / employees. Exemple : ‘The company plans to recruit two engineers this year.’",
+            "difficulty": "easy",
+            "tags": ["toeic", "starter", "human-resources", "recruit"],
+        },
+        {
+            "concept_name": "Vocabulaire professionnel",
+            "question": "Ressources humaines — Quel nom désigne le programme d’accueil et d’intégration d’un nouvel employé ?",
+            "answer": "orientation — programme d’accueil et d’intégration. Collocation : attend an orientation session. Exemple : ‘New employees attend orientation on their first day.’",
+            "difficulty": "medium",
+            "tags": ["toeic", "starter", "human-resources", "orientation"],
+        },
+        {
+            "concept_name": "Vocabulaire professionnel",
+            "question": "Ressources humaines — Quel nom désigne des avantages offerts en plus du salaire ?",
+            "answer": "benefits — avantages sociaux. Collocation : employee benefits. Exemple : ‘Health insurance is one of the employee benefits.’",
+            "difficulty": "medium",
+            "tags": ["toeic", "starter", "human-resources", "benefits"],
+        },
+        {
+            "concept_name": "Vocabulaire professionnel",
+            "question": "Ressources humaines — Quel nom désigne une période d’essai ?",
+            "answer": "probation — période d’essai. Collocation : probation period. Exemple : ‘Her probation period ends in September.’",
+            "difficulty": "medium",
+            "tags": ["toeic", "starter", "human-resources", "probation"],
+        },
+        {
+            "concept_name": "Vocabulaire professionnel",
+            "question": "Relation client — Quel nom désigne une estimation de prix envoyée avant une vente ?",
+            "answer": "quote — devis. Collocation : provide / request a quote. Exemple : ‘We provided a quote for the maintenance service.’",
+            "difficulty": "medium",
+            "tags": ["toeic", "starter", "customer-service", "quote"],
+        },
+        {
+            "concept_name": "Vocabulaire professionnel",
+            "question": "Relation client — Quel document demande le paiement de biens ou services fournis ?",
+            "answer": "invoice — facture. Collocation : issue / pay an invoice. Exemple : ‘The supplier issued the invoice yesterday.’",
+            "difficulty": "easy",
+            "tags": ["toeic", "starter", "customer-service", "invoice"],
+        },
+        {
+            "concept_name": "Vocabulaire professionnel",
+            "question": "Relation client — Quel document officiel autorise l’achat auprès d’un fournisseur ?",
+            "answer": "purchase order — bon de commande. Collocation : place / process a purchase order. Exemple : ‘The buyer placed a purchase order for new monitors.’",
+            "difficulty": "hard",
+            "tags": ["toeic", "starter", "customer-service", "purchase-order"],
+        },
+        {
+            "concept_name": "Vocabulaire professionnel",
+            "question": "Relation client — Quel verbe signifie négocier des conditions ou un prix ?",
+            "answer": "negotiate — négocier. Collocation : negotiate terms / a contract. Exemple : ‘Both companies negotiated the contract terms.’",
+            "difficulty": "medium",
+            "tags": ["toeic", "starter", "customer-service", "negotiate"],
+        },
+        {
+            "concept_name": "Vocabulaire professionnel",
+            "question": "Relation client — Quel nom désigne une réclamation d’un client ?",
+            "answer": "complaint — réclamation. Collocation : handle / file a complaint. Exemple : ‘The service team handled the complaint promptly.’",
+            "difficulty": "easy",
+            "tags": ["toeic", "starter", "customer-service", "complaint"],
+        },
+        {
+            "concept_name": "Vocabulaire professionnel",
+            "question": "Relation client — Quel nom désigne le remboursement d’un client ?",
+            "answer": "refund — remboursement. Collocation : issue / request a refund. Exemple : ‘The store issued a refund within two days.’",
+            "difficulty": "easy",
+            "tags": ["toeic", "starter", "customer-service", "refund"],
+        },
+        {
+            "concept_name": "Vocabulaire professionnel",
+            "question": "Logistique et déplacements — Quel nom désigne un envoi de marchandises ?",
+            "answer": "shipment — expédition, envoi. Collocation : track a shipment. Exemple : ‘You can track the shipment online.’",
+            "difficulty": "medium",
+            "tags": ["toeic", "starter", "logistics-travel", "shipment"],
+        },
+        {
+            "concept_name": "Vocabulaire professionnel",
+            "question": "Logistique et déplacements — Quel nom désigne la remise effective d’un colis ou d’une commande ?",
+            "answer": "delivery — livraison. Collocation : delivery date / confirm delivery. Exemple : ‘The customer confirmed the delivery this morning.’",
+            "difficulty": "easy",
+            "tags": ["toeic", "starter", "logistics-travel", "delivery"],
+        },
+        {
+            "concept_name": "Vocabulaire professionnel",
+            "question": "Logistique et déplacements — Quel nom désigne le stock de produits disponible ?",
+            "answer": "inventory — stock, inventaire. Collocation : check / manage inventory. Exemple : ‘The warehouse team checks inventory weekly.’",
+            "difficulty": "medium",
+            "tags": ["toeic", "starter", "logistics-travel", "inventory"],
+        },
+        {
+            "concept_name": "Vocabulaire professionnel",
+            "question": "Logistique et déplacements — Quel nom désigne le lieu où les marchandises sont entreposées ?",
+            "answer": "warehouse — entrepôt. Collocation : warehouse manager. Exemple : ‘The warehouse is close to the airport.’",
+            "difficulty": "easy",
+            "tags": ["toeic", "starter", "logistics-travel", "warehouse"],
+        },
+        {
+            "concept_name": "Vocabulaire professionnel",
+            "question": "Logistique et déplacements — Quel nom désigne un programme détaillé de voyage ou de visite ?",
+            "answer": "itinerary — itinéraire, programme de voyage. Collocation : travel itinerary. Exemple : ‘Your travel itinerary includes two client visits.’",
+            "difficulty": "hard",
+            "tags": ["toeic", "starter", "logistics-travel", "itinerary"],
+        },
+        {
+            "concept_name": "Vocabulaire professionnel",
+            "question": "Logistique et déplacements — Quel verbe signifie fournir un hébergement ou s’adapter à un besoin ?",
+            "answer": "accommodate — héberger, répondre à un besoin. Collocation : accommodate a request. Exemple : ‘The hotel can accommodate late arrivals.’",
+            "difficulty": "hard",
+            "tags": ["toeic", "starter", "logistics-travel", "accommodate"],
+        },
+        {
+            "concept_name": "Vocabulaire professionnel",
+            "question": "Finances et rapports — Quel nom désigne le budget prévu pour une activité ?",
+            "answer": "budget — budget. Collocation : stay within / approve a budget. Exemple : ‘The project stayed within its budget.’",
+            "difficulty": "easy",
+            "tags": ["toeic", "starter", "finance-reporting", "budget"],
+        },
+        {
+            "concept_name": "Vocabulaire professionnel",
+            "question": "Finances et rapports — Quel nom désigne les revenus d’une entreprise issus de ses ventes ?",
+            "answer": "revenue — chiffre d’affaires, recettes. Collocation : increase revenue. Exemple : ‘Online sales increased revenue last quarter.’",
+            "difficulty": "medium",
+            "tags": ["toeic", "starter", "finance-reporting", "revenue"],
+        },
+        {
+            "concept_name": "Vocabulaire professionnel",
+            "question": "Finances et rapports — Quel nom désigne une dépense engagée par l’entreprise ?",
+            "answer": "expense — dépense. Collocation : reduce operating expenses. Exemple : ‘The team reduced travel expenses this year.’",
+            "difficulty": "medium",
+            "tags": ["toeic", "starter", "finance-reporting", "expense"],
+        },
+        {
+            "concept_name": "Vocabulaire professionnel",
+            "question": "Finances et rapports — Quel nom désigne une estimation de résultats futurs ?",
+            "answer": "forecast — prévision. Collocation : sales forecast. Exemple : ‘The sales forecast was revised in April.’",
+            "difficulty": "medium",
+            "tags": ["toeic", "starter", "finance-reporting", "forecast"],
+        },
+        {
+            "concept_name": "Vocabulaire professionnel",
+            "question": "Finances et rapports — Quel adjectif signifie trimestriel ?",
+            "answer": "quarterly — trimestriel. Collocation : quarterly report. Exemple : ‘The quarterly report is ready for review.’",
+            "difficulty": "medium",
+            "tags": ["toeic", "starter", "finance-reporting", "quarterly"],
+        },
+        {
+            "concept_name": "Vocabulaire professionnel",
+            "question": "Finances et rapports — Quel verbe signifie attribuer des ressources ou un budget ?",
+            "answer": "allocate — attribuer, allouer. Collocation : allocate funds / resources. Exemple : ‘The board allocated funds to staff training.’",
+            "difficulty": "hard",
+            "tags": ["toeic", "starter", "finance-reporting", "allocate"],
+        },
+    ],
+}
+
+
+def get_starter_pack(template_id: str) -> dict | None:
+    """Return a defensive copy of the starter pack associated with a template."""
+    if template_id != TOEIC_FOUNDATIONS_PACK["template_id"]:
+        return None
+    return deepcopy(TOEIC_FOUNDATIONS_PACK)

--- a/src/routes/mastery.py
+++ b/src/routes/mastery.py
@@ -1,11 +1,12 @@
 """Routes des parcours de maîtrise multi-domaines."""
 
-from datetime import date
+from datetime import date, datetime, timezone
 
 from flask import Blueprint, jsonify, request
 from flask_jwt_extended import get_jwt_identity, jwt_required
 
-from src.models.user import Concept, Subject, db
+from src.content.toeic_foundations import get_starter_pack
+from src.models.user import Card, Concept, Subject, db
 from src.services.domain_catalog import DOMAIN_OPTIONS, find_template, public_catalog
 
 mastery_bp = Blueprint("mastery", __name__)
@@ -32,12 +33,13 @@ def _parse_weekly_hours(value):
     return hours
 
 
-def _create_path(user_id: int, data: dict) -> Subject:
-    """Create a path chosen by the user, optionally from a transparent template."""
+def _create_path(user_id: int, data: dict) -> tuple[Subject, dict | None]:
+    """Create a user-selected path and its optional transparent starter pack."""
     template_id = data.get("template_id")
     template = find_template(template_id) if template_id else None
     if template_id and not template:
         raise ValueError("Unknown learning path template")
+    starter_pack = get_starter_pack(template_id) if template else None
 
     if template:
         name = template["title"]
@@ -101,8 +103,24 @@ def _create_path(user_id: int, data: dict) -> Subject:
             evidence_criterion=concept.get("evidence_criterion", ""),
         ))
 
+    if starter_pack:
+        now = datetime.now(timezone.utc).replace(tzinfo=None)
+        for card_data in starter_pack["cards"]:
+            db.session.add(Card(
+                user_id=user_id,
+                subject_id=subject.id,
+                learning_domain=starter_pack["learning_domain"],
+                concept_name=card_data["concept_name"],
+                front_content=card_data["question"],
+                back_content=card_data["answer"],
+                difficulty=card_data.get("difficulty", "medium"),
+                priority="normal",
+                tags=",".join(card_data.get("tags", [])),
+                next_review=now,
+            ))
+
     db.session.commit()
-    return subject
+    return subject, starter_pack
 
 
 @mastery_bp.route("/subjects", methods=["GET"])
@@ -147,8 +165,17 @@ def create_learning_path():
     """Create a free path or a user-selected editorial template."""
     try:
         user_id = int(get_jwt_identity())
-        subject = _create_path(user_id, request.get_json(silent=True) or {})
-        return jsonify({"status": "success", "subject": subject.to_dict()}), 201
+        subject, starter_pack = _create_path(user_id, request.get_json(silent=True) or {})
+        response = {"status": "success", "subject": subject.to_dict()}
+        if starter_pack:
+            response["starter_pack"] = {
+                "id": starter_pack["id"],
+                "title": starter_pack["title"],
+                "cards_created": len(starter_pack["cards"]),
+                "learning_domain": starter_pack["learning_domain"],
+                "disclaimer": "Jeu de départ éditorial : complétez-le avec vos propres contenus et une pratique variée.",
+            }
+        return jsonify(response), 201
     except ValueError as exc:
         db.session.rollback()
         return jsonify({"status": "error", "message": str(exc)}), 400
@@ -164,7 +191,7 @@ def create_plan():
     try:
         user_id = int(get_jwt_identity())
         payload = request.get_json(silent=True) or {}
-        subject = _create_path(user_id, {
+        subject, _ = _create_path(user_id, {
             "name": payload.get("subject", payload.get("name", "")),
             "description": payload.get("description", ""),
             "domain": payload.get("domain", "general"),

--- a/tests/test_backend_flask.py
+++ b/tests/test_backend_flask.py
@@ -12,7 +12,7 @@ os.environ["JWT_SECRET_KEY"] = "test-jwt-secret-with-enough-length-for-hs256"
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from main import app, get_database_uri, should_auto_create_tables  # noqa: E402
-from src.models.user import Concept, StudySession, Subject, db  # noqa: E402
+from src.models.user import Card, Concept, StudySession, Subject, db  # noqa: E402
 from src.utils import document_extraction  # noqa: E402
 
 
@@ -287,11 +287,38 @@ def test_custom_learning_path_supports_goal_and_deadline(client, auth_headers):
     assert subject["concepts"][0]["competency_type"] == "procedure"
 
 
+def test_toeic_template_creates_original_starter_cards(client, auth_headers):
+    response = client.post(
+        "/api/mastery/create-path",
+        headers=auth_headers,
+        json={"template_id": "toeic-foundations"},
+    )
+
+    assert response.status_code == 201
+    payload = response.get_json()
+    assert payload["starter_pack"]["id"] == "toeic-business-vocabulary-foundations-v1"
+    assert payload["starter_pack"]["cards_created"] == 36
+    assert payload["starter_pack"]["learning_domain"] == "language"
+
+    subject_id = payload["subject"]["id"]
+    cards = Card.query.filter_by(subject_id=subject_id).all()
+    assert len(cards) == 36
+    assert {card.learning_domain for card in cards} == {"language"}
+    assert all("toeic" in card.tags.split(",") for card in cards)
+    assert all(card.next_review is not None for card in cards)
+
+
 def test_adaptive_profiles_filter_sessions_and_apply_domain_retention(client, auth_headers):
     language_path_response = client.post(
         "/api/mastery/create-path",
         headers=auth_headers,
-        json={"template_id": "toeic-foundations"},
+        json={
+            "name": "Anglais professionnel de contrôle",
+            "domain": "language",
+            "description": "Parcours isolé pour vérifier le filtrage adaptatif.",
+            "objective_type": "competency",
+            "objective_label": "Réviser une carte de vocabulaire.",
+        },
     )
     computing_path_response = client.post(
         "/api/mastery/create-path",


### PR DESCRIPTION
## Objet

Ajoute au modèle **Préparation TOEIC** un socle éditorial original de 36 cartes de vocabulaire professionnel, disponibles dès la création explicite du parcours.

## Contenu

- 6 thèmes : réunions, courriel/projets, RH, relation client, logistique/déplacements, finances/rapports ;
- question de rappel actif, correction concise, collocation et exemple original pour chaque carte ;
- cartes marquées `learning_domain=language`, immédiatement éligibles à FSRS ;
- message d’interface confirmant l’ajout du socle ;
- documentation de conception, d’usage et de périmètre, avec références publiques ;
- test d’intégration du contrat de création et ajustement du scénario adaptatif isolé.

## Garanties

Ce paquet ne reproduit aucune question, aucun passage ni audio d’examen TOEIC et ne fait aucune promesse de score. Il constitue un point de départ à compléter par écoute, lecture, production et contenu personnel.

## Validations

- `pytest tests/test_backend_flask.py tests/test_fsrs_scheduler.py -q` : 19 réussis ;
- `npm run lint` : réussi ;
- `npm run build` : réussi.

Le build signale uniquement la base Browserslist/caniuse-lite obsolète, sans échec de compilation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Nouvelles fonctionnalités**
  - Ajout d’un parcours TOEIC avec 36 cartes originales de vocabulaire professionnel.
  - Les cartes couvrent six thèmes : réunions, e-mails et projets, ressources humaines, service client, logistique et voyages, finance et reporting.
  - Les cartes sont automatiquement planifiées pour la révision et intégrées aux vues d’apprentissage adaptatives.
  - La confirmation de création indique désormais le nombre de cartes ajoutées lorsque le parcours inclut un pack de démarrage.

- **Documentation**
  - Ajout de guides en français présentant le parcours, son utilisation, ses sources et ses extensions prévues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->